### PR TITLE
Add link to album in last.fm on album picture

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ jobs:
         with:
           LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
           LASTFM_USER: ${{ secrets.LASTFM_USER }}
+#         INCLUDE_LINK: true # Optional. Defaults is false. If you want to include the link to the album page, set this to true.
 #         IMAGE_COUNT: 6 # Optional. Defaults to 10. Feel free to remove this line if you want.
       - name: commit changes
         continue-on-error: true

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: false
     default: '10'
 
+  INCLUDE_LINK:
+    description: 'Include a link to the album on Last.fm.'
+    required: false
+    default: false
+
 runs:
   using: 'composite'
   steps:
@@ -24,6 +29,7 @@ runs:
         LASTFM_API_KEY: ${{ inputs.LASTFM_API_KEY }}
         LASTFM_USER: ${{ inputs.LASTFM_USER }}
         IMAGE_COUNT: ${{ inputs.IMAGE_COUNT }}
+        INCLUDE_LINK: ${{ inputs.INCLUDE_LINK }}
       run: python ${{ github.action_path }}/lastfm.py
       shell: bash
       

--- a/lastfm.py
+++ b/lastfm.py
@@ -28,9 +28,11 @@ def get_album_covers(artist_and_album):
         payload = {'method': 'album.getinfo',
                    'artist': album[0],
                    'album': album[1]}
-        url = lastfm_request(payload).json()['album']['image'][1]['#text']
+        request_response = lastfm_request(payload).json()
+        url = request_response['album']['image'][1]['#text']
+        link_to_album = request_response['album']['url']
         if (url != ''):
-            images.append([album[0], album[1], url])
+            images.append([album[0], album[1], url, link_to_album])
     return images
 
 

--- a/lastfm.py
+++ b/lastfm.py
@@ -45,7 +45,7 @@ def update_readme(images):
     for img in images:
         if (i < int(os.getenv('IMAGE_COUNT'))):
             if (requests.get(img[2]).status_code == 200):
-                if not os.getenv('INCLUDE_LINK'):
+                if os.getenv('INCLUDE_LINK') == 'false':
                     lastfm_line += f'<img src="{img[2]}" title="{img[0]} - {img[1]}"> '
                 else:
                     lastfm_line += f'<a href="{img[3]}"><img src="{img[2]}" title="{img[0]} - {img[1]}"></a> '

--- a/lastfm.py
+++ b/lastfm.py
@@ -45,7 +45,10 @@ def update_readme(images):
     for img in images:
         if (i < int(os.getenv('IMAGE_COUNT'))):
             if (requests.get(img[2]).status_code == 200):
-                lastfm_line = lastfm_line + '<img src="' + img[2] + '" title="' + img[0] + ' - ' + img[1] + '"> '
+                if not os.getenv('INCLUDE_LINK'):
+                    lastfm_line += f'<img src="{img[2]}" title="{img[0]} - {img[1]}"> '
+                else:
+                    lastfm_line += f'<a href="{img[3]}"><img src="{img[2]}" title="{img[0]} - {img[1]}"></a> '
                 # lastfm_line = lastfm_line + '![' + img[0] + ' - ' + img[1] + '](' + img[2] + ') '
                 i = i + 1
             else:


### PR DESCRIPTION
Hi! I use your workflow for a while now and I think that it's better if someone curious that what's the album and currently when we click on the album it will send you to the image file. 

<img width="1317" alt="CleanShot 2565-02-25 at 11 57 37@2x" src="https://user-images.githubusercontent.com/68165621/155656425-9b6607d1-ed63-46d1-aeab-fed6f5bd7894.png">

So I think that why we just add the link to the last.fm page on that album and when someone curious what's album there so just click that album.

![CleanShot 2565-02-25 at 11 59 07](https://user-images.githubusercontent.com/68165621/155656555-0db526a7-42dc-4bea-9989-c53e82cbeb44.gif)

# New parameter

To make this as an optional option I add `INCLUDE_LINK` parameter to the setup. It's optional and the default value is false so if you want to enable the link just add `INCLUDE_LINK: true` to the setup. I have updated setup detail on readme.

# Result sample

I release the tag on my fork and try it on my [profile repository](https://github.com/HelloYeew/HelloYeew) so you can see the sample result from here. The visual is the same as before add the link.

About the code, I test on `INCLUDE_LINK` value and it's return as `true` or `false` as string so I need to make the condition as `os.getenv('INCLUDE_LINK') == 'false'`.